### PR TITLE
More robust resource lookup

### DIFF
--- a/gwt-resources/processor/src/main/java/org/gwtproject/resources/context/AbstractClientBundleGenerator.java
+++ b/gwt-resources/processor/src/main/java/org/gwtproject/resources/context/AbstractClientBundleGenerator.java
@@ -269,16 +269,17 @@ public abstract class AbstractClientBundleGenerator extends Generator {
   private Class<? extends ResourceGenerator> findResourceGenerator(
       TreeLogger logger, ExecutableElement method) throws UnableToCompleteException {
     TypeElement resourceType = MoreTypes.asTypeElement(method.getReturnType());
-    if (aptContext.generators.containsKey(resourceType)) {
-      return aptContext.generators.get(resourceType);
+    Class<? extends ResourceGenerator> generator;
+    if ((generator = aptContext.getGenerator(resourceType)) != null) {
+      return generator;
     } else {
       List<? extends TypeMirror> parents =
           new ArrayList<>(ResourceGeneratorUtil.getAllParents(resourceType));
       Collections.reverse(parents);
       for (TypeMirror p : parents) {
         Element parent = aptContext.types.asElement(p);
-        if (aptContext.generators.containsKey(parent)) {
-          return aptContext.generators.get(parent);
+        if ((generator = aptContext.getGenerator(parent)) != null) {
+          return generator;
         }
       }
 

--- a/gwt-resources/processor/src/main/java/org/gwtproject/resources/context/AptContext.java
+++ b/gwt-resources/processor/src/main/java/org/gwtproject/resources/context/AptContext.java
@@ -116,14 +116,29 @@ public class AptContext {
             e -> {
               ResourceGeneratorType resourceGeneratorType =
                   e.getAnnotation(ResourceGeneratorType.class);
-              String resourceGeneratorName = resourceGeneratorType.value();
-              try {
-                generators.put(
-                    e, (Class<? extends ResourceGenerator>) Class.forName(resourceGeneratorName));
-              } catch (ClassNotFoundException e1) {
-                e1.printStackTrace();
-                throw new Error(e1);
-              }
+              addType(e, resourceGeneratorType);
             });
+  }
+
+  private void addType(Element e, ResourceGeneratorType resourceGeneratorType) {
+    String resourceGeneratorName = resourceGeneratorType.value();
+    try {
+      Class<? extends ResourceGenerator> value = (Class<? extends ResourceGenerator>) Class.forName(resourceGeneratorName);
+      generators.put(
+              e, value);
+    } catch (ClassNotFoundException e1) {
+      e1.printStackTrace();
+      throw new Error(e1);
+    }
+  }
+
+  Class<? extends ResourceGenerator> getGenerator(Element resourceType) {
+    if (!generators.containsKey(resourceType)) {
+      ResourceGeneratorType generatorType = resourceType.getAnnotation(ResourceGeneratorType.class);
+      if (generatorType != null) {
+        addType(resourceType, generatorType);
+      }
+    }
+    return generators.get(resourceType);
   }
 }

--- a/gwt-resources/processor/src/main/java/org/gwtproject/resources/rg/resource/impl/ResourceOracleImpl.java
+++ b/gwt-resources/processor/src/main/java/org/gwtproject/resources/rg/resource/impl/ResourceOracleImpl.java
@@ -304,9 +304,9 @@ public class ResourceOracleImpl implements ResourceOracle {
       if (new File(fileObject.getName()).exists()) {
         return fileObject.toUri().toURL();
       }
-    } catch (FilerException ignored) {
+    } catch (FilerException filerException) {
       File openedfile =
-          new File(ignored.getMessage().replace("Attempt to reopen a file for path ", ""));
+          new File(filerException.getMessage().replace("Attempt to reopen a file for path ", ""));
       if (openedfile.exists()) {
         try {
           return openedfile.toURI().toURL();
@@ -317,6 +317,8 @@ public class ResourceOracleImpl implements ResourceOracle {
       // ignored
     } catch (IOException ignored) {
       // ignored
+    } catch (RuntimeException ignored) {
+      // getResource may throw IllegalArgumentException or NullPointerException on some JDKs
     }
     return null;
   }


### PR DESCRIPTION
* ignore NPEs that come randomly from some JDKs
* support resource interfaces that are on classpath but not in current annotation round

(replacement for https://github.com/treblereel/gwt-resources/pull/31 )