### PR TITLE
Fix capitalization in module dependency

### DIFF
--- a/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/i18n/I18N.gwt.xml
+++ b/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/i18n/I18N.gwt.xml
@@ -2,7 +2,7 @@
 <module>
   <inherits name="elemental2.dom.Dom"/>
 
-  <inherits name="org.gwtproject.i18n.I18n"/>
+  <inherits name="org.gwtproject.i18n.I18N"/>
 
   <inherits name="org.gwtproject.safehtml.SafeHtml"/>
 


### PR DESCRIPTION
With `I18n` I get an error about missing module. However the proposed change results in 2 different `gwt.xml` files called `I18N.gwt.xml` in package `org.gwtproject.i18n` -- not sure if that's valid, hence the draft status.