### PR TITLE
Do not inherit from com.google modules

### DIFF
--- a/gwt-uibinder/gwt-uibinder-client/src/main/resources/org/gwtproject/uibinder/UiBinder.gwt.xml
+++ b/gwt-uibinder/gwt-uibinder-client/src/main/resources/org/gwtproject/uibinder/UiBinder.gwt.xml
@@ -17,7 +17,7 @@
 
 -->
 <module>
-  <inherits name="com.google.gwt.resources.Resources"/>
+  <inherits name="org.gwtproject.resources.Resources"/>
 
   <inherits name="org.gwtproject.dom.DOM"/>
 


### PR DESCRIPTION
It seems the old module name was left during migration from com.google