### PR TITLE
Remove unused @JsConstructor annotation

### DIFF
--- a/gwt-widgets/gwt-widgets/src/main/java/org/gwtproject/user/client/ui/impl/ClippedImagePrototype.java
+++ b/gwt-widgets/gwt-widgets/src/main/java/org/gwtproject/user/client/ui/impl/ClippedImagePrototype.java
@@ -39,7 +39,6 @@ public class ClippedImagePrototype extends AbstractImagePrototype {
   private int width = 0;
   private boolean isDraggable = false;
 
-  @JsConstructor
   public ClippedImagePrototype(SafeUri url, int left, int top, int width, int height) {
     this.url = url;
     this.left = left;


### PR DESCRIPTION
to avoid `unusable-by-js` warning in GWT2 compilation