### PR TITLE
Tree: fix infinite recursion and classcast

### DIFF
--- a/gwt-bom/pom.xml
+++ b/gwt-bom/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.treblereel.gwt.gwtproject</groupId>
     <artifactId>gwt-bom</artifactId>
-    <version>202203291</version>
+    <version>202206111</version>
     <packaging>pom</packaging>
     <name>GWTProject BOM (Bill Of Materials)</name>
     <description>GWTProject BOM (Bill Of Materials)</description>

--- a/gwt-internal-bom/pom.xml
+++ b/gwt-internal-bom/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.treblereel.gwt.gwtproject</groupId>
     <artifactId>gwt-internal-bom</artifactId>
-    <version>202203291</version>
+    <version>202206111</version>
     <packaging>pom</packaging>
     <name>GWTPROJECT Internal BOM (Bill Of Materials)</name>
     <description>GWTProject Internal BOM (Bill Of Materials)</description>

--- a/gwt-resources/processor/dependency-reduced-pom.xml
+++ b/gwt-resources/processor/dependency-reduced-pom.xml
@@ -109,7 +109,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -121,25 +120,17 @@
           </plugin>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
                 <goals>
                   <goal>jar</goal>
                 </goals>
-                <configuration>
-                  <failOnError>false</failOnError>
-                </configuration>
               </execution>
             </executions>
-            <configuration>
-              <failOnError>false</failOnError>
-            </configuration>
           </plugin>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/gwt-resources/processor/src/main/java/org/gwtproject/resources/context/AptContext.java
+++ b/gwt-resources/processor/src/main/java/org/gwtproject/resources/context/AptContext.java
@@ -123,9 +123,9 @@ public class AptContext {
   private void addType(Element e, ResourceGeneratorType resourceGeneratorType) {
     String resourceGeneratorName = resourceGeneratorType.value();
     try {
-      Class<? extends ResourceGenerator> value = (Class<? extends ResourceGenerator>) Class.forName(resourceGeneratorName);
-      generators.put(
-              e, value);
+      Class<? extends ResourceGenerator> value =
+          (Class<? extends ResourceGenerator>) Class.forName(resourceGeneratorName);
+      generators.put(e, value);
     } catch (ClassNotFoundException e1) {
       e1.printStackTrace();
       throw new Error(e1);

--- a/gwt-widgets/gwt-widgets/src/main/java/org/gwtproject/user/client/ui/Tree.java
+++ b/gwt-widgets/gwt-widgets/src/main/java/org/gwtproject/user/client/ui/Tree.java
@@ -1171,7 +1171,7 @@ public class Tree extends Widget
       DOM.appendChild(holder, proto.createElement());
     } else {
       // Otherwise, simply apply the prototype to the existing element.
-      proto.applyTo(Js.<Image>uncheckedCast(child));
+      proto.applyTo(Js.<AbstractImagePrototype.ImagePrototypeElement>uncheckedCast(child));
     }
   }
 

--- a/gwt-widgets/gwt-widgets/src/main/java/org/gwtproject/user/client/ui/TreeItem.java
+++ b/gwt-widgets/gwt-widgets/src/main/java/org/gwtproject/user/client/ui/TreeItem.java
@@ -750,14 +750,11 @@ public class TreeItem extends UIObject implements IsTreeItem, HasTreeItems, HasH
    * @return the focusable item
    */
   protected Focusable getFocusable() {
-    Focusable focus = getFocusable();
-    if (focus == null) {
-      Widget w = getWidget();
-      if (w instanceof Focusable) {
-        focus = (Focusable) w;
-      }
+    Widget w = getWidget();
+    if (w instanceof Focusable) {
+      return (Focusable) w;
     }
-    return focus;
+    return null;
   }
 
   /**

--- a/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/i18n/I18N.gwt.xml
+++ b/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/i18n/I18N.gwt.xml
@@ -2,7 +2,7 @@
 <module>
   <inherits name="elemental2.dom.Dom"/>
 
-  <inherits name="org.gwtproject.i18n.I18n"/>
+  <inherits name="org.gwtproject.i18n.I18N"/>
 
   <inherits name="org.gwtproject.safehtml.SafeHtml"/>
 

--- a/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/text/Text.gwt.xml
+++ b/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/text/Text.gwt.xml
@@ -2,7 +2,7 @@
 <module>
   <inherits name="elemental2.dom.Dom"/>
 
-  <!--  <inherits name="org.gwtproject.i18n.I18n"/>
+  <!--  <inherits name="org.gwtproject.i18n.I18N"/>
     <inherits name="org.gwtproject.i18n.DateTimeFormat"/>-->
   <inherits name="org.gwtproject.safehtml.SafeHtml"/>
 

--- a/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/user/Widgets.gwt.xml
+++ b/gwt-widgets/gwt-widgets/src/main/resources/org/gwtproject/user/Widgets.gwt.xml
@@ -45,6 +45,7 @@
     <inherits name="org.gwtproject.i18n.I18N" />
     <inherits name="org.gwtproject.text.Text" />
     <inherits name="org.gwtproject.resources.Resources" />
+    <inherits name="org.gwtproject.validation.Validation" />
 
     <source path="client/ui"/>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     </modules>
 
     <properties>
-        <revision>202203291</revision>
+        <revision>202206111</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
* the `getFocusable` and `getFocusableWidget`  [methods of TreeItem](https://github.com/gwtproject/gwt/blob/c32238861c4d58bc559d303ab44f91ddd4e10685/user/src/com/google/gwt/user/client/ui/TreeItem.java#L803) were merged incorrectly, causing infinite recursion 
* image element was cast to `Image` widget, which is bound to fail